### PR TITLE
Add pointer to the new blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Monitoring the Kubernetes/OpenShift cluster to observe the impact of Kraken chao
 ### Blogs and other useful resources
 - Blog post on introduction to Kraken: https://www.openshift.com/blog/introduction-to-kraken-a-chaos-tool-for-openshift/kubernetes
 - Discussion and demo on how Kraken can be leveraged to ensure OpenShift is reliable, performant and scalable: https://www.youtube.com/watch?v=s1PvupI5sD0&ab_channel=OpenShift
-
+- Blog post emphasizing the importance of making Chaos part of Performance and Scale runs to mimic the production environments: https://www.openshift.com/blog/making-chaos-part-of-kubernetes/openshift-performance-and-scalability-tests
 
 ### Contributions
 We are always looking for more enhancements, fixes to make it better, any contributions are most welcome. Feel free to report or work on the issues filed on github. 

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -318,7 +318,7 @@ def main(cfg):
         iterations = config["tunings"].get("iterations", 1)
         daemon_mode = config["tunings"].get("daemon_mode", False)
         deploy_performance_dashboards = config["performance_monitoring"].get("deploy_dashboards", False)
-        dashboard_repo = config["performance_monitoring"].get("repo", "https://github.com/cloud-bulldozer/performance-dashboards.git")
+        dashboard_repo = config["performance_monitoring"].get("repo", "https://github.com/cloud-bulldozer/performance-dashboards.git") # noqa
 
         # Initialize clients
         if not os.path.isfile(kubeconfig_path):

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = {posargs}
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.
 show-source = True
-max-line-length = 100
+max-line-length = 120
 ignore = E123,E125
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build


### PR DESCRIPTION
This commit:
- Adds a pointer to a new blog which emphasizes the importance
  of making chaos part of Perf/Scale test runs.
- Bumps up the allowed max-line-length for the linters.
