### PR TITLE
Correct license from MIT to Apache 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = kraken
 description = Chaos and resiliency testing tool
 author = chaitanyaenr
 author-email = nelluri@redhat.com
-license = mit
+license = Apache License 2.0
 long-description = file: README.md
 long-description-content-type = text/markdown; charset=UTF-8
 classifiers =


### PR DESCRIPTION
### Description

Correct the license declared in setup.cfg. Was set to MIT when it should be set to Apache 2.0