### PR TITLE
Monitor user application availability during chaos

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This will manage the Cerberus and Elasticsearch containers on the host on which 
 ### Config
 Instructions on how to setup the config and the options supported can be found at [Config](docs/config.md).
 
+
 ### Kubernetes/OpenShift chaos scenarios supported
 Kraken supports pod, node, time/date and [litmus](https://github.com/litmuschaos/litmus) based scenarios.
 
@@ -48,10 +49,11 @@ Kraken supports pod, node, time/date and [litmus](https://github.com/litmuschaos
 
 - [Namespace Scenarios](docs/namespace_scenarios.md)
 
+
 ### Kraken scenario pass/fail criteria and report
 It's important to make sure to check if the targeted component recovered from the chaos injection and also if the Kubernetes/OpenShift cluster is healthy as failures in one component can have an adverse impact on other components. Kraken does this by:
 - Having built in checks for pod and node based scenarios to ensure the expected number of replicas and nodes are up. It also supports running custom scripts with the checks.
-- Leveraging [Cerberus](https://github.com/openshift-scale/cerberus) to monitor the cluster under test and consuming the aggregated go/no-go signal to determine pass/fail. It is highly recommended to turn on the Cerberus health check feature avaliable in Kraken. Instructions on installing and setting up Cerberus can be found [here](https://github.com/openshift-scale/cerberus#installation). Once Cerberus is up and running, set cerberus_enabled to True and cerberus_url to the url where Cerberus publishes go/no-go signal in the Kraken config file.
+- Leveraging [Cerberus](https://github.com/openshift-scale/cerberus) to monitor the cluster under test and consuming the aggregated go/no-go signal to determine pass/fail post chaos. It is highly recommended to turn on the Cerberus health check feature avaliable in Kraken. Instructions on installing and setting up Cerberus can be found [here](https://github.com/openshift-scale/cerberus#installation) or can be installed from Kraken using the [instructions](https://github.com/cloud-bulldozer/kraken#setting-up-infrastructure-dependencies). Once Cerberus is up and running, set cerberus_enabled to True and cerberus_url to the url where Cerberus publishes go/no-go signal in the Kraken config file. Cerberus can monitor [application routes](https://github.com/cloud-bulldozer/cerberus/blob/master/docs/config.md#watch-routes) during the chaos and fails the run if it encounters downtime as it's a potential downtime in customer, users environment as well. It is especially important during the control plane chaos scenarios including the API server, Etcd, Ingress etc. It can be enabled by setting `check_applicaton_routes: True` in the [Kraken config](https://github.com/cloud-bulldozer/kraken/blob/master/config/config.yaml) provided application routes are being monitored in the [cerberus config](https://github.com/cloud-bulldozer/kraken/blob/master/config/cerberus.yaml)
 - Leveraging [kube-burner](docs/alerts.md) alerting feature to fail the runs in case of critical alerts.
 
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,15 +21,17 @@ kraken:
         -   litmus_scenarios:                              # List of litmus scenarios to load
             - - https://hub.litmuschaos.io/api/chaos/1.10.0?file=charts/generic/node-cpu-hog/rbac.yaml
               - scenarios/node_hog_engine.yaml
-        - cluster_shut_down_scenarios:
+        -   cluster_shut_down_scenarios:
             - - scenarios/cluster_shut_down_scenario.yml
               - scenarios/post_action_shut_down.py
         -   namespace_scenarios:
             - scenarios/regex_namespace.yaml
             - scenarios/ingress_namespace.yaml
+
 cerberus:
     cerberus_enabled: False                                # Enable it when cerberus is previously installed
     cerberus_url:                                          # When cerberus_enabled is set to True, provide the url where cerberus publishes go/no-go signal
+    check_applicaton_routes: False                         # When enabled will look for application unavailability using the routes specified in the cerberus config and fails the run
 
 performance_monitoring:
     deploy_dashboards: False                              # Install a mutable grafana and load the performance dashboards. Enable this only when running on OpenShift

--- a/config/config_performance.yaml
+++ b/config/config_performance.yaml
@@ -28,6 +28,7 @@ kraken:
 cerberus:
     cerberus_enabled: True                                # Enable it when cerberus is previously installed
     cerberus_url: http://0.0.0.0:8080                     # When cerberus_enabled is set to True, provide the url where cerberus publishes go/no-go signal
+    check_applicaton_routes: False                         # When enabled will look for application unavailability using the routes specified in the cerberus config and fails the run
 
 performance_monitoring:
     deploy_dashboards: True                               # Install a mutable grafana and load the performance dashboards. Enable this only when running on OpenShift

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,35 +1,4 @@
 ### Config
-Set the scenarios to inject and the tunings like duration to wait between each scenario in the config file located at config/config.yaml. A sample config looks like:
+Set the scenarios to inject and the tunings like duration to wait between each scenario in the config file located at [config/config.yaml](https://github.com/cloud-bulldozer/kraken/blob/master/config/config.yaml).
 
-```
-kraken:
-    kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
-    exit_on_failure: False                                 # Exit when a post action scenario fails
-    chaos_scenarios:                                         # List of policies/chaos scenarios to load
-        -   pod_scenarios:                                 # List of chaos pod scenarios to load
-            - -    scenarios/etcd.yml
-            - -    scenarios/regex_openshift_pod_kill.yml
-              -    scenarios/post_action_regex.py
-        -   node_scenarios:                                # List of chaos node scenarios to load
-            -   scenarios/node_scenarios_example.yml
-        -   pod_scenarios:
-            - -    scenarios/openshift-apiserver.yml
-            - -    scenarios/openshift-kube-apiserver.yml
-        -   time_scenarios:                                # List of chaos time scenarios to load
-            - scenarios/time_scenarios_example.yml
-
-cerberus:
-    cerberus_enabled: False                                # Enable it when cerberus is previously installed
-    cerberus_url:                                          # When cerberus_enabled is set to True, provide the url where cerberus publishes go/no-go signal
-
-performance_monitoring:
-    deploy_dashboards: False                              # Install a mutable grafana and load the performance dashboards. Enable this only when running on OpenShift
-    repo: "https://github.com/cloud-bulldozer/performance-dashboards.git"
-
-tunings:
-    wait_duration: 60                                      # Duration to wait between each chaos scenario
-    iterations: 1                                          # Number of times to execute the scenarios
-    daemon_mode: False                                     # Iterations are set to infinity which means that the kraken will cause chaos forever
-```
-
-**NOTE**: [config](https://github.com/cloud-bulldozer/kraken/tree/master/config/config_performance.yaml) can be used if leveraging the automated way to install the infrastruture pieces.
+**NOTE**: [config](https://github.com/cloud-bulldozer/kraken/tree/master/config/config_performance.yaml) can be used if leveraging the [automated way](https://github.com/cloud-bulldozer/kraken#setting-up-infrastructure-dependencies) to install the infrastruture pieces.

--- a/kraken/cerberus/setup.py
+++ b/kraken/cerberus/setup.py
@@ -1,24 +1,42 @@
 import logging
 import requests
 import sys
+import json
 
 
 # Get cerberus status
-def get_status(config):
+def get_status(config, start_time, end_time):
     cerberus_status = True
+    check_application_routes = False
+    application_routes_status = True
     if config["cerberus"]["cerberus_enabled"]:
         cerberus_url = config["cerberus"]["cerberus_url"]
+        check_application_routes = config["cerberus"]["check_applicaton_routes"]
         if not cerberus_url:
             logging.error("url where Cerberus publishes True/False signal is not provided.")
             sys.exit(1)
-        cerberus_status = requests.get(cerberus_url).content
+        cerberus_status = requests.get(cerberus_url, timeout=60).content
         cerberus_status = True if cerberus_status == b"True" else False
+
+        # Fail if the application routes monitored by cerberus experience downtime during the chaos
+        if check_application_routes:
+            application_routes_status, unavailable_routes = application_status(cerberus_url, start_time, end_time)
+            if not application_routes_status:
+                logging.error(
+                    "Application routes: %s monitored by cerberus encountered downtime during the run, failing"
+                    % unavailable_routes
+                )
+            else:
+                logging.info("Application routes being monitored didn't encounter any downtime during the run!")
+
         if not cerberus_status:
             logging.error(
                 "Received a no-go signal from Cerberus, looks like "
                 "the cluster is unhealthy. Please check the Cerberus "
                 "report for more details. Test failed."
             )
+
+        if not application_routes_status or not cerberus_status:
             sys.exit(1)
         else:
             logging.info("Received a go signal from Ceberus, the cluster is healthy. " "Test passed.")
@@ -26,8 +44,8 @@ def get_status(config):
 
 
 # Function to publish kraken status to cerberus
-def publish_kraken_status(config, failed_post_scenarios):
-    cerberus_status = get_status(config)
+def publish_kraken_status(config, failed_post_scenarios, start_time, end_time):
+    cerberus_status = get_status(config, start_time, end_time)
     if not cerberus_status:
         if failed_post_scenarios:
             if config["kraken"]["exit_on_failure"]:
@@ -46,3 +64,30 @@ def publish_kraken_status(config, failed_post_scenarios):
                 sys.exit(1)
             else:
                 logging.info("Cerberus status is healthy but post action scenarios " "are still failing")
+
+
+# Check application availability
+def application_status(cerberus_url, start_time, end_time):
+    if not cerberus_url:
+        logging.error("url where Cerberus publishes True/False signal is not provided.")
+        sys.exit(1)
+    else:
+        duration = (end_time - start_time) / 60
+        url = cerberus_url + "/" + "history" + "?" + "loopback=" + str(duration)
+        logging.info("Scraping the metrics for the test duration from cerberus url: %s" % url)
+        try:
+            failed_routes = []
+            status = True
+            metrics = requests.get(url, timeout=60).content
+            metrics_json = json.loads(metrics)
+            for entry in metrics_json["history"]["failures"]:
+                if entry["component"] == "route":
+                    name = entry["name"]
+                    failed_routes.append(name)
+                    status = False
+                else:
+                    continue
+        except Exception as e:
+            logging.error("Failed to scrape metrics from cerberus API at %s: %s" % (url, e))
+            sys.exit(1)
+    return status, set(failed_routes)

--- a/kraken/litmus/common_litmus.py
+++ b/kraken/litmus/common_litmus.py
@@ -11,6 +11,7 @@ import kraken.cerberus.setup as cerberus
 def run(scenarios_list, config, litmus_namespaces, litmus_uninstall, wait_duration):
     # Loop to run the scenarios starts here
     for l_scenario in scenarios_list:
+        start_time = int(time.time())
         try:
             for item in l_scenario:
                 runcommand.invoke("kubectl apply -f %s" % item)
@@ -45,7 +46,8 @@ def run(scenarios_list, config, litmus_namespaces, litmus_uninstall, wait_durati
                     runcommand.invoke("kubectl delete -f %s" % item)
             logging.info("Waiting for the specified duration: %s" % wait_duration)
             time.sleep(wait_duration)
-            cerberus.get_status(config)
+            end_time = int(time.time())
+            cerberus.get_status(config, start_time, end_time)
         except Exception as e:
             logging.error("Failed to run litmus scenario: %s. Encountered " "the following exception: %s" % (item, e))
             sys.exit(1)

--- a/kraken/namespace_actions/common_namespace_functions.py
+++ b/kraken/namespace_actions/common_namespace_functions.py
@@ -19,6 +19,7 @@ def run(scenarios_list, config, wait_duration):
                 namespace_action = scenario.get("action", "delete")
                 run_sleep = scenario.get("sleep", 10)
                 namespaces = kubecli.check_namespaces([scenario_namespace], scenario_label)
+                start_time = int(time.time())
                 for i in range(run_count):
                     if len(namespaces) == 0:
                         logging.error(
@@ -35,10 +36,12 @@ def run(scenarios_list, config, wait_duration):
                             namespace_action + " on namespace " + str(selected_namespace) + " was unsuccessful"
                         )
                         logging.info("Namespace action error: " + str(e))
+                        sys.exit(1)
                     namespaces.remove(selected_namespace)
                     logging.info("Waiting %s seconds between namespace deletions" % str(run_sleep))
                     time.sleep(run_sleep)
 
                 logging.info("Waiting for the specified duration: %s" % wait_duration)
                 time.sleep(wait_duration)
-                cerberus.get_status(config)
+                end_time = int(time.time())
+                cerberus.get_status(config, start_time, end_time)

--- a/kraken/node_actions/run.py
+++ b/kraken/node_actions/run.py
@@ -51,10 +51,12 @@ def run(scenarios_list, config, wait_duration):
                 node_scenario_object = get_node_scenario_object(node_scenario)
                 if node_scenario["actions"]:
                     for action in node_scenario["actions"]:
+                        start_time = int(time.time())
                         inject_node_scenario(action, node_scenario, node_scenario_object)
                         logging.info("Waiting for the specified duration: %s" % (wait_duration))
                         time.sleep(wait_duration)
-                        cerberus.get_status(config)
+                        end_time = int(time.time())
+                        cerberus.get_status(config, start_time, end_time)
                         logging.info("")
 
 

--- a/kraken/shut_down/common_shut_down_func.py
+++ b/kraken/shut_down/common_shut_down_func.py
@@ -112,10 +112,12 @@ def run(scenarios_list, config, wait_duration):
         with open(shut_down_config[0], "r") as f:
             shut_down_config_yaml = yaml.full_load(f)
             shut_down_config_scenario = shut_down_config_yaml["cluster_shut_down_scenario"]
+            start_time = int(time.time())
             cluster_shut_down(shut_down_config_scenario)
             logging.info("Waiting for the specified duration: %s" % (wait_duration))
             time.sleep(wait_duration)
             failed_post_scenarios = post_actions.check_recovery(
                 "", shut_down_config, failed_post_scenarios, pre_action_output
             )
-            cerberus.publish_kraken_status(config, failed_post_scenarios)
+            end_time = int(time.time())
+            cerberus.publish_kraken_status(config, failed_post_scenarios, start_time, end_time)

--- a/kraken/time_actions/common_time_functions.py
+++ b/kraken/time_actions/common_time_functions.py
@@ -143,10 +143,12 @@ def run(scenarios_list, config, wait_duration):
         with open(time_scenario_config, "r") as f:
             scenario_config = yaml.full_load(f)
             for time_scenario in scenario_config["time_scenarios"]:
+                start_time = int(time.time())
                 object_type, object_names = skew_time(time_scenario)
                 not_reset = check_date_time(object_type, object_names)
                 if len(not_reset) > 0:
                     logging.info("Object times were not reset")
                 logging.info("Waiting for the specified duration: %s" % (wait_duration))
                 time.sleep(wait_duration)
-                cerberus.publish_kraken_status(config, not_reset)
+                end_time = int(time.time())
+                cerberus.publish_kraken_status(config, not_reset, start_time, end_time)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -126,6 +126,7 @@ def main(cfg):
                             failed_post_scenarios = pod_scenarios.container_run(
                                 kubeconfig_path, scenarios_list, config, failed_post_scenarios, wait_duration
                             )
+
                         # Inject node chaos scenarios specified in the config
                         elif scenario_type == "node_scenarios":
                             logging.info("Running node scenarios")
@@ -135,6 +136,8 @@ def main(cfg):
                         elif scenario_type == "time_scenarios":
                             logging.info("Running time skew scenarios")
                             time_actions.run(scenarios_list, config, wait_duration)
+
+                        # Inject litmus based chaos scenarios
                         elif scenario_type == "litmus_scenarios":
                             logging.info("Running litmus scenarios")
                             if not litmus_installed:
@@ -144,12 +147,16 @@ def main(cfg):
                             litmus_namespaces = common_litmus.run(
                                 scenarios_list, config, litmus_namespaces, litmus_uninstall, wait_duration,
                             )
+
+                        # Inject cluster shutdown scenarios
                         elif scenario_type == "cluster_shut_down_scenarios":
                             shut_down.run(scenarios_list, config, wait_duration)
 
+                        # Inject namespace chaos scenarios
                         elif scenario_type == "namespace_scenarios":
                             logging.info("Running namespace scenarios")
                             namespace_actions.run(scenarios_list, config, wait_duration)
+
             iteration += 1
             logging.info("")
 


### PR DESCRIPTION
### Description
Current Kraken integration with Cerberus monitors the cluster as well
as the application health post chaos and pass/fails if they are not
healthy after chaos. This commit adds ability to monitor the user
application health during the chaos and fails the run in case of
downtime as it's potentially a downtime in case of customers environment
as well. It is especially useful in case of control plane failure
scenarios including API server, Etcd, Ingress etc.




