### PR TITLE
Run tasks in pod using Job object type

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -23,6 +23,6 @@ To run containerized Kraken as a Kubernetes/OpenShift Deployment, follow these s
 6. Create a ConfigMap named scenarios-config using `kubectl create configmap scenarios-config --from-file=<path_to_scenarios_folder>`
 7. Create a serviceaccount to run the kraken pod `kubectl create serviceaccount useroot`.
 8. In Openshift, add privileges to service account and execute `oc adm policy add-scc-to-user privileged -z useroot`.
-9. Create a Deployment and a NodePort Service using `kubectl apply -f kraken.yml`
+9. Create a Job using `kubectl apply -f kraken.yml` and monitor the status using `oc get jobs` and `oc get pods`.
 
 NOTE: It is not recommended to run Kraken internal to the cluster as the pod which is running Kraken might get disrupted.

--- a/containers/kraken.yml
+++ b/containers/kraken.yml
@@ -1,13 +1,11 @@
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name: kraken-deployment
+  name: kraken
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      tool: Kraken
+  parallelism: 1
+  completions: 1
   template:
     metadata:
       labels:
@@ -21,8 +19,6 @@ spec:
           image: quay.io/openshift-scale/kraken
           command: ["/bin/sh", "-c"]
           args: ["python3 run_kraken.py -c config/config.yaml"]
-          ports:
-            - containerPort: 8080
           volumeMounts:
             - mountPath: "/root/.kube"
               name: config
@@ -30,6 +26,7 @@ spec:
               name: kraken-config
             - mountPath: "/root/kraken/scenarios"
               name: scenarios-config
+      restartPolicy: Never
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
### Description
This commit switches the object type from Deployment to Job to be able
to display the status after executing all the scenarios specified in
the Kraken config instead of crashing which is expected in Deployments.

### Fixes
Fixes https://github.com/cloud-bulldozer/kraken/issues/135