### PR TITLE
Run all the litmus resources in a single namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Instructions on how to setup the config and the options supported can be found a
 
 
 ### Kubernetes/OpenShift chaos scenarios supported
-Kraken supports pod, node, time/date and [litmus](https://github.com/litmuschaos/litmus) based scenarios.
 
 - [Pod Scenarios](docs/pod_scenarios.md)
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,6 +4,7 @@ kraken:
     exit_on_failure: False                                 # Exit when a post action scenario fails
     litmus_version: v1.13.6                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
+    litmus_namespace: litmus                               # Namespace to configure and run litmus based scenarios
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   container_scenarios:                                 # List of chaos pod scenarios to load
             - -    scenarios/container_etcd.yml
@@ -19,11 +20,11 @@ kraken:
         -   time_scenarios:                                # List of chaos time scenarios to load
             - scenarios/time_scenarios_example.yml
         -   litmus_scenarios:                              # List of litmus scenarios to load
-            - - https://hub.litmuschaos.io/api/chaos/1.13.6?file=charts/generic/node-cpu-hog/rbac.yaml
+            - - https://raw.githubusercontent.com/cloud-bulldozer/kraken/master/scenarios/templates/litmus-rbac.yaml
               - scenarios/node_cpu_hog_engine.yaml
-            - - https://hub.litmuschaos.io/api/chaos/1.13.6?file=charts/generic/node-memory-hog/rbac.yaml
+            - - https://raw.githubusercontent.com/cloud-bulldozer/kraken/master/scenarios/templates/litmus-rbac.yaml
               - scenarios/node_mem_engine.yaml
-            - - https://hub.litmuschaos.io/api/chaos/1.13.6?file=charts/generic/node-io-stress/rbac.yaml
+            - - https://raw.githubusercontent.com/cloud-bulldozer/kraken/master/scenarios/templates/litmus-rbac.yaml
               - scenarios/node_io_engine.yaml
         -   cluster_shut_down_scenarios:
             - - scenarios/cluster_shut_down_scenario.yml

--- a/config/config_performance.yaml
+++ b/config/config_performance.yaml
@@ -4,6 +4,7 @@ kraken:
     exit_on_failure: False                                 # Exit when a post action scenario fails
     litmus_version: v1.10.0                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
+    litmus_namespace: litmus                               # Namespace to configure and run litmus based scenarios
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   pod_scenarios:                                 # List of chaos pod scenarios to load
             - -    scenarios/etcd.yml

--- a/scenarios/node_cpu_hog_engine.yaml
+++ b/scenarios/node_cpu_hog_engine.yaml
@@ -2,13 +2,13 @@ apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
   name: nginx-chaos
-  namespace: default
+  namespace: litmus
 spec:
   # It can be true/false
   annotationCheck: 'false'
   # It can be active/stop
   engineState: 'active'
-  chaosServiceAccount: node-cpu-hog-sa
+  chaosServiceAccount: litmus-sa
   monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
@@ -23,7 +23,7 @@ spec:
 
             # Number of cores of node CPU to be consumed
             - name: NODE_CPU_CORE
-              value: ''
+              value: '1'
 
             # percentage of total nodes to target
             - name: NODES_AFFECTED_PERC
@@ -31,4 +31,4 @@ spec:
 
             # ENTER THE COMMA SEPARATED TARGET NODES NAME
             - name: TARGET_NODES
-              value: ''
+              value: '<node_name>'

--- a/scenarios/node_io_engine.yaml
+++ b/scenarios/node_io_engine.yaml
@@ -2,13 +2,13 @@ apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
   name: nginx-chaos
-  namespace: default
+  namespace: litmus
 spec:
   # It can be delete/retain
   jobCleanUpPolicy: 'retain'
   # It can be active/stop
   engineState: 'active'
-  chaosServiceAccount: node-io-stress-sa
+  chaosServiceAccount: litmus-sa
   experiments:
     - name: node-io-stress
       spec:

--- a/scenarios/node_mem_engine.yaml
+++ b/scenarios/node_mem_engine.yaml
@@ -2,13 +2,13 @@ apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
   name: nginx-chaos
-  namespace: default
+  namespace: litmus
 spec:
   # It can be delete/retain
   jobCleanUpPolicy: 'retain'
   # It can be active/stop
   engineState: 'active'
-  chaosServiceAccount: node-memory-hog-sa
+  chaosServiceAccount: litmus-sa
   experiments:
     - name: node-memory-hog
       spec:

--- a/scenarios/templates/litmus-rbac.yaml
+++ b/scenarios/templates/litmus-rbac.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: litmus-sa
+  namespace: litmus
+  labels:
+    name: litmus-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: litmus-sa
+  labels:
+    name: litmus-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+- apiGroups: [""]
+  resources: ["pods","events"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
+- apiGroups: [""]
+  resources: ["pods/exec","pods/log"]
+  verbs: ["list","get","create"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create","list","get","delete","deletecollection"]
+- apiGroups: ["litmuschaos.io"]
+  resources: ["chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: litmus-sa
+  labels:
+    name: litmus-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: litmus-sa
+subjects:
+- kind: ServiceAccount
+  name: litmus-sa
+  namespace: litmus


### PR DESCRIPTION
### Description
    - This eases the usage and debuggability by running the fault injection pods in
      the same namespace as other resources of litmus. This will also ease the
      deletion process and ensure that there are no leftover objects on the cluster.
    
    - This commit also enables users to use the same rbac template for all the litmus
      scenarios without having to pull in a specific one for each of the scenarios.

