### PR TITLE
Delete litmus crd's during the cleanup

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,6 @@ kraken:
     exit_on_failure: False                                 # Exit when a post action scenario fails
     litmus_version: v1.13.6                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
-    litmus_namespace: litmus                               # Namespace to configure and run litmus based scenarios
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   container_scenarios:                                 # List of chaos pod scenarios to load
             - -    scenarios/container_etcd.yml

--- a/config/config_performance.yaml
+++ b/config/config_performance.yaml
@@ -4,7 +4,6 @@ kraken:
     exit_on_failure: False                                 # Exit when a post action scenario fails
     litmus_version: v1.10.0                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
-    litmus_namespace: litmus                               # Namespace to configure and run litmus based scenarios
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   pod_scenarios:                                 # List of chaos pod scenarios to load
             - -    scenarios/etcd.yml

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -37,7 +37,6 @@ def main(cfg):
         chaos_scenarios = config["kraken"].get("chaos_scenarios", [])
         litmus_version = config["kraken"].get("litmus_version", "v1.9.1")
         litmus_uninstall = config["kraken"].get("litmus_uninstall", False)
-        litmus_namespace = config["kraken"].get("litmus_namespace", "litmus")
         wait_duration = config["tunings"].get("wait_duration", 60)
         iterations = config["tunings"].get("iterations", 1)
         daemon_mode = config["tunings"].get("daemon_mode", False)
@@ -141,6 +140,7 @@ def main(cfg):
                         # Inject litmus based chaos scenarios
                         elif scenario_type == "litmus_scenarios":
                             logging.info("Running litmus scenarios")
+                            litmus_namespace = "litmus"
                             if not litmus_installed:
                                 # Will always uninstall first
                                 common_litmus.delete_chaos(litmus_namespace)


### PR DESCRIPTION
This commit will ensure that the litmus resources installed on the
cluster get cleaned up and also creates the chaosengine in the
specified namespace.
