### PR TITLE
Prioritize filtering on namespace to improve performance

### DIFF
--- a/run_kraken.py
+++ b/run_kraken.py
@@ -209,7 +209,11 @@ def main(cfg):
             logging.error("Post scenarios are still failing at the end of all iterations")
             sys.exit(1)
 
-        logging.info("Successfully finished running Kraken. UUID for the run: %s. Exiting" % (run_uuid))
+        run_dir = os.getcwd() + "/kraken.report"
+        logging.info(
+            "Successfully finished running Kraken. UUID for the run: %s. Report generated at %s. Exiting"
+            % (run_uuid, run_dir)
+        )
     else:
         logging.error("Cannot find a config at %s, please check" % (cfg))
         sys.exit(1)

--- a/scenarios/time_scenarios_example.yml
+++ b/scenarios/time_scenarios_example.yml
@@ -1,7 +1,8 @@
 time_scenarios:
   - action: skew_time
     object_type: pod
-    label_selector: app=multus
+    namespace: openshift-etcd
+    label_selector: app=etcd
   - action: skew_date
     object_type: node
     label_selector: node-role.kubernetes.io/worker


### PR DESCRIPTION
This will avoid querying all namespaces for pods matching the label_selector
if defined as shown in the sample scenario config. This commit also prints a
pointer to the report generated at the end of the run.
