### PR TITLE
Pull images from quay instead of docker

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM quay.io/openshift/origin-tests:latest as origintests
 
-FROM centos:7
+FROM quay.io/centos/centos:7
 
 MAINTAINER Red Hat OpenShift Performance and Scale
 


### PR DESCRIPTION
This is needed to avoid getting rate limited. Build for reference -
https://recovery.quay.io/repository/openshift-scale/kraken/build/0cccc967-cfef-43d0-98ca-e3eccb698045.
