### PR TITLE
Bump jinja2 version to use latest MarkupSafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ openshift-client
 python-ipmi
 podman-compose
 docker-compose
-jinja2
+jinja2>=3.0.1


### PR DESCRIPTION
### Description
By default a jinja2 version less then 3.0.1 is installed, which raises error "cannot import name 'soft_unicode' from 'markupsafe'".
Using jinja2 3.0.1 or greater avoids this issue.


