### PR TITLE
Task Solved: Ability to pass scenarios to run over http

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 kraken:
     distribution: openshift                                # Distribution can be kubernetes or openshift
-    kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
+    kubeconfig_path: /root/scale-ci-svishwak-cluster1-aws/auth/kubeconfig                    # Path to kubeconfig
     exit_on_failure: False                                 # Exit when a post action scenario fails
     port: 8081
     publish_kraken_status: True                            # Can be accessed at http://0.0.0.0:8081

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,11 +9,9 @@ kraken:
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
     action: "Send HTTP request to http://0.0.0.0:8081"
     type: "HTTP"
-    notification_url: "$url"
+    notification_url: "http://0.0.0.0:8081"
     method: "POST"
-    variables:
-    - key: "url"
-      value: "http://0.0.0.0:8081"
+    
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   container_scenarios:                                 # List of chaos pod scenarios to load
             - -    scenarios/container_etcd.yml

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 kraken:
     distribution: openshift                                # Distribution can be kubernetes or openshift
-    kubeconfig_path: /root/scale-ci-svishwak-cluster1-aws/auth/kubeconfig                    # Path to kubeconfig
+    kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
     exit_on_failure: False                                 # Exit when a post action scenario fails
     port: 8081
     publish_kraken_status: True                            # Can be accessed at http://0.0.0.0:8081

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,11 +7,6 @@ kraken:
     signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
     litmus_version: v1.13.6                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
-    action: "Send HTTP request to http://0.0.0.0:8081"
-    type: "HTTP"
-    notification_url: "http://0.0.0.0:8081"
-    method: "POST"
-    
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   container_scenarios:                                 # List of chaos pod scenarios to load
             - -    scenarios/container_etcd.yml

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,6 +7,13 @@ kraken:
     signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
     litmus_version: v1.13.6                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
+    action: "Send HTTP request to http://0.0.0.0:8081"
+    type: "HTTP"
+    notification_url: "$url"
+    method: "POST"
+    variables:
+    - key: "url"
+      value: "http://0.0.0.0:8081"
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   container_scenarios:                                 # List of chaos pod scenarios to load
             - -    scenarios/container_etcd.yml

--- a/docs/index.md
+++ b/docs/index.md
@@ -204,3 +204,24 @@ Let’s take a look at few recommendations on how and where to run the chaos tes
 - Run multiple chaos tests at once to mimic the production outages
   - For example, hogging both IO and Network at the same time instead of running them separately to observe the impact.
   - You might have existing test cases, be it related to Performance, Scalability or QE, run the chaos in the background during the test runs to observe the impact. Signaling feature in Kraken can help with coordinating the chaos runs i.e start, stop, pause the scenarios based on the state of the other test jobs.
+
+
+#### Chaos testing in Practice within the OpenShift Organization
+
+Within the OpenShift organization we use kraken to perform chaos testing throughout a release before the code is available to customers
+
+    1. We execute kraken during our regression test suite
+
+        i. We cover each of the chaos scenarios across different clouds
+
+            a. Our testing is predominantly done on AWS, Azure and GCP
+
+    2. We run the chaos scenarios during a long running reliability test
+
+        i. During this test we perform different types of tasks by different users on the cluster
+
+        ii. We have added the execution of kraken to perform a certain times throughout the long running test and monitor the health of the cluster
+
+        iii. This test can be seen here: https://github.com/openshift/svt/tree/master/reliability-v2
+
+    3. We are starting to add in test cases that perform chaos testing during an upgrade (not many iterations of this have been completed)

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,8 @@ Bandwidth is infinite.
 The network is secure.
 Topology never changes.
 The network is homogeneous.
-Consistent resource usage with no spikes
+Consistent resource usage with no spikes.
+All shared resources are available from all places.
 
 The assumptions led to a number of outages in production environments in the past.  The services suffered from poor performance or were inaccessible to the customers, leading to missing Service Level Agreement uptime promises, revenue loss, and a degradation in the perceived reliability of said services..
 
@@ -73,7 +74,7 @@ We want to look at this in terms of CPU, Memory, Disk, Throughput, Network etc.
   - The controller watching the component should recognize a failure as soon as possible. The component needs to have minimal initialization time to avoid extended downtime or overloading the replicas if it is a highly available configuration. The cause of failure can be because of issues with the infrastructure on top of which it’s running, application failures or because of service failures that it depends on.
 
 - High Availability deployment strategy
-  - There should be multiple replicas ( both OpenShift and application control planes ) running preferably in different availability zones to survive outages while still serving the user/system requests.
+  - There should be multiple replicas ( both OpenShift and application control planes ) running preferably in different availability zones to survive outages while still serving the user/system requests. Avoid single points of failure.
 - Backed by persistent storage
   - It’s important to have the system/application backed by persistent storage. This is especially important in cases where the application is a database or a stateful application given that a node, pod or container failure will wipe off the data.
 
@@ -132,7 +133,7 @@ Let’s take a look at how to run the chaos scenarios on your OpenShift clusters
 - Zone Outages ([Documentation](https://github.com/cloud-bulldozer/kraken-hub/blob/main/docs/zone-outages.md))
   - Creates outage of availability zone(s) in a targeted region in the public cloud where the OpenShift cluster is running by tweaking the network acl of the zone to simulate the failure and that in turn will stop both ingress and egress traffic from all the nodes in a particular zone for the specified duration and reverts it back to the previous state
     - Helps understand the impact on both Kubernetes/OpenShift control plane as well as applications, services running on the worker nodes in that zone.
-    - Currently only set up for AWS cloud platform
+    - Currently only set up for AWS cloud platform: 1 VPC and multiples subnets within the VPC can be specified
     - [Demo](https://asciinema.org/a/452672?speed=3&theme=solarized-dark)
 
 - Application outages ([Documentation](https://github.com/cloud-bulldozer/kraken-hub/blob/main/docs/application-outages.md))
@@ -162,8 +163,8 @@ Let’s take a look at how to run the chaos scenarios on your OpenShift clusters
   - Delete namespaces for the specified duration
     - Helps understand the  impact on other components and test/improve recovery time of the components in the targeted namespace
 
-- Persistent volume fill ([Documentation]())
-  - Fills up the persistent volumes used by the pod for the specified duration
+- Persistent volume fill ([Documentation](https://github.com/cloud-bulldozer/kraken-hub/blob/main/docs/pvc-scenarios.md))
+  - Fills up the persistent volumes, up to a given percentage, used by the pod for the specified duration
     - Helps understand how an application deals when it’s no longer able to write data to the disk. For example kafka’s behavior when it’s not able to commit data to the disk.
 
 - Network Chaos ([Documentation](https://github.com/cloud-bulldozer/kraken-hub/blob/main/docs/network-chaos.md))
@@ -185,6 +186,10 @@ Let’s take a look at few recommendations on how and where to run the chaos tes
 - Run the chaos tests continuously in your test pipelines
   - Software, systems, and infrastructure does change – and the condition/health of each can change pretty rapidly. A good place to run the tests is in your CI/CD pipeline running on a regular cadence.
 
+- Run the chaos tests manually to learn from the system
+  - When running a Chaos scenario or a Fault tests, it’s more important to understand how the system respond and reacts rather than mark the execution as pass or failed.
+  - It’s important to define the scope of the test before the execution to avoid some issues from masking others.
+
 - Run the chaos tests in production environments or mimic the load in staging environments:
   - As scary as a thought about testing in production is, production is the environment that users are in and traffic spikes/load are real. To fully test the robustness/resilience of a production system, running Chaos Engineering experiments in a production environment will provide needed insights. A couple of things to keep in mind:
     - Minimize blast radius and have a backup plan in place to make sure the users and customers do not undergo downtime.
@@ -194,6 +199,7 @@ Let’s take a look at few recommendations on how and where to run the chaos tes
   - Chaos Engineering Without Observability ... Is Just Chaos
   - Make sure to have logging and monitoring installed on the cluster to help with understanding the behaviour as to why it’s happening. In case of running the tests in the CI where it’s not humanly possible to monitor the cluster all the time, it’s recommended to leverage Cerberus to capture the state during the runs and metrics collection in Kraken to store metrics long term even after the cluster is gone.
   - Kraken ships with dashboards that will help understand API, Etcd and OpenShift cluster level stats and performance metrics.
+  - Pay attention to Prometheus alerts. Check if they are firing as expected.
 
 - Run multiple chaos tests at once to mimic the production outages
   - For example, hogging both IO and Network at the same time instead of running them separately to observe the impact.

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ Now that we understand the test methodology, let’s take a look at the best pra
 - Alerts with appropriate severity should get fired
   - Alerts are key to identify when a component starts degrading,  and can help focus the investigation effort on affected system components.
   - Alerts should have proper severity,description, notification policy, escalation policy, and SOPin order to reduce MTTR for responding SRE or Ops resources.
-
+  - Detailed information on the alerts consistency can be found [here](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md).
 
 - Minimal performance impact - Network, CPU, Memory, Disk, Throughput etc.
   - The system, as well as the applications, should be designed to have minimal performance impact during disruptions to ensure stability and also to avoid hogging resources that other applications can use.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,6 +20,8 @@ $ cd kraken
 
 #### Install the dependencies
 ```
+$ python3 -m venv chaos
+$ source chaos/bin/activate
 $ pip3 install -r requirements.txt
 ```
 

--- a/kraken/kubernetes/client.py
+++ b/kraken/kubernetes/client.py
@@ -135,9 +135,9 @@ def get_all_pods(label_selector=None):
 
 
 # Execute command in pod
-def exec_cmd_in_pod(command, pod_name, namespace, container=None):
+def exec_cmd_in_pod(command, pod_name, namespace, container=None, base_command="bash"):
 
-    exec_command = ["bash", "-c", command]
+    exec_command = [base_command, "-c", command]
     try:
         if container:
             ret = stream(

--- a/kraken/pvc/pvc_scenario.py
+++ b/kraken/pvc/pvc_scenario.py
@@ -104,7 +104,7 @@ pvc_name: '%s'\npod_name: '%s'\nnamespace: '%s'\ntarget_fill_percentage: '%s%%'\
                 # Get used bytes in PVC
                 command = "du -sk %s | grep -Eo '^[0-9]*'" % (str(mount_path))
                 logging.debug("Get used bytes in PVC command:\n %s" % command)
-                pvc_used = kubecli.exec_cmd_in_pod(command, pod_name, namespace, container_name)
+                pvc_used = kubecli.exec_cmd_in_pod(command, pod_name, namespace, container_name, "sh")
                 logging.info("PVC used: %s KB" % pvc_used)
 
                 # Check valid fill percentage
@@ -134,7 +134,7 @@ pvc_name: '%s'\npod_name: '%s'\nnamespace: '%s'\ntarget_fill_percentage: '%s%%'\
                 full_path = "%s/%s" % (str(mount_path), str(file_name))
                 command = "dd bs=1024 count=%s </dev/urandom >%s" % (str(file_size), str(full_path))
                 logging.debug("Create temp file in the PVC command:\n %s" % command)
-                response = kubecli.exec_cmd_in_pod(command, pod_name, namespace, container_name)
+                response = kubecli.exec_cmd_in_pod(command, pod_name, namespace, container_name, "sh")
                 logging.info("\n" + str(response))
                 if "copied" in str(response).lower():
                     logging.info("%s file successfully created" % (str(full_path)))
@@ -150,10 +150,10 @@ pvc_name: '%s'\npod_name: '%s'\nnamespace: '%s'\ntarget_fill_percentage: '%s%%'\
                 # Remove the temp file from the PVC
                 command = "rm %s" % (str(full_path))
                 logging.debug("Remove temp file from the PVC command:\n %s" % command)
-                kubecli.exec_cmd_in_pod(command, pod_name, namespace, container_name)
+                kubecli.exec_cmd_in_pod(command, pod_name, namespace, container_name, "sh")
                 command = "ls %s" % (str(mount_path))
                 logging.debug("Check temp file is removed command:\n %s" % command)
-                response = kubecli.exec_cmd_in_pod(command, pod_name, namespace, container_name)
+                response = kubecli.exec_cmd_in_pod(command, pod_name, namespace, container_name, "sh")
                 logging.info("\n" + str(response))
                 if not (file_name in str(response).lower()):
                     logging.info("Temp file successfully removed")

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ openshift-client
 python-ipmi
 podman-compose
 docker-compose
-jinja2
+jinja2>=3.0.1

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -44,16 +44,19 @@ def main(cfg):
 	path=o.path
 	res=os.path.split(path)
 	cfg=res[1]'''
-    f = requests.get(cfg)
-    cfg=f.text
+    '''f = requests.get(cfg)
+    cfg=f.text'''
 
     # Parse and read the config
-    if os.path.isfile(cfg):
-	#if urlparse(cfg):
+    #if os.path.isfile(cfg):
+    if urlparse(cfg):
 	    #o=urlparse(cfg)
 	    #path=o.path
 	    #res=os.path.split(path)
 	    #cfg=res[1]
+	f = requests.get(cfg)
+        cfg=f.text
+
         with open(cfg, "r") as f:
             config = yaml.full_load(f)
         global kubeconfig_path, wait_duration

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -38,12 +38,14 @@ def main(cfg):
     # Start kraken
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
-    print(cfg)
-    #if urlparse(cfg):
-	#o=urlparse(cfg)
-	#path=o.path
-	#res=os.path.split(path)
-	#cfg=res[1]
+    
+    '''if urlparse(cfg):
+	o=urlparse(cfg)
+	path=o.path
+	res=os.path.split(path)
+	cfg=res[1]'''
+    f = requests.get(cfg)
+    cfg=f.text
 
     # Parse and read the config
     if os.path.isfile(cfg):
@@ -310,7 +312,4 @@ if __name__ == "__main__":
 	    path=o.path
 	    res=os.path.split(path)
 	    options.cfg=res[1]'''
-	print(options.cfg)
-	f = requests.get(options.cfg)
-	options.cfg=f.text
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -62,10 +62,10 @@ def main(cfg):
             config = yaml.full_load(f)'''
 	f = requests.get(cfg)
     	texts=f.text
-	with open(texts,'r') as file:
-            config = yaml.full_load(file)
-
-	#config=yaml.safe_load(texts)
+	'''with open(texts,'r') as file:
+            config = yaml.full_load(file)'''
+       
+	config=yaml.safe_load(texts)
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
         kubeconfig_path = config["kraken"].get("kubeconfig_path", "")

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -42,7 +42,10 @@ def main(cfg):
     logging.info("Starting kraken")
 
     # Parse and read the config
-    #if os.path.isfile(path):
+    if os.path.isfile(cfg):
+        with open(cfg, "r") as f:
+            config = yaml.full_load(f)
+   
     if urlparse(cfg):
 	f = requests.get(cfg)
     	texts=f.text

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -24,6 +24,7 @@ import kraken.pvc.pvc_scenario as pvc_scenario
 import kraken.network_chaos.actions as network_chaos
 import server as server
 from urllib.parse import urlparse
+import webbrowser
 
 
 def publish_kraken_status(status):
@@ -36,10 +37,13 @@ def main(cfg):
     # Start kraken
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
-
-    if urlparse(cfg):
-	o=urlparse(cfg)
-	cfg=o.path
+    new=2
+    webbrowser.open(url,new=new)
+    #if urlparse(cfg):
+	#o=urlparse(cfg)
+	#path=o.path
+	#res=os.path.split(path)
+	#cfg=res[1]
 
     # Parse and read the config
     if os.path.isfile(cfg):

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -23,6 +23,7 @@ import kraken.application_outage.actions as application_outage
 import kraken.pvc.pvc_scenario as pvc_scenario
 import kraken.network_chaos.actions as network_chaos
 import server as server
+from urllib.parse import urlparse
 
 
 def publish_kraken_status(status):
@@ -35,6 +36,10 @@ def main(cfg):
     # Start kraken
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
+
+    if urlparse(cfg):
+	o=urlparse(cfg)
+	cfg=o.path
 
     # Parse and read the config
     if os.path.isfile(cfg):

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -61,7 +61,8 @@ def main(cfg):
         '''with open(cfg, "r") as f:
             config = yaml.full_load(f)'''
 	f = requests.get(cfg)
-    	config=f.text
+    	texts=f.text
+	config=yaml.safe_load(texts)
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
         kubeconfig_path = config["kraken"].get("kubeconfig_path", "")

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -47,9 +47,9 @@ def main(cfg):
             config = yaml.full_load(f)
    
     if urlparse(cfg):
-	f = requests.get(cfg)
+	    f = requests.get(cfg)
     	texts=f.text
-	config=yaml.safe_load(texts)
+	    config=yaml.safe_load(texts)
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
         kubeconfig_path = config["kraken"].get("kubeconfig_path", "")
@@ -302,5 +302,5 @@ if __name__ == "__main__":
         sys.exit(1)
     else:
 	#pdb.set_trace()
-	print(options.cfg)
+	    print(options.cfg)
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -39,18 +39,18 @@ def main(cfg):
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
     
-    path=cfg
+    '''path=cfg
     if urlparse(cfg):
 	o=urlparse(cfg)
-	path=o.path
+	path=o.path'''
 	'''res=os.path.split(path)
 	cfg=res[1]'''
     '''f = requests.get(cfg)
     texts=f.text'''
 
     # Parse and read the config
-    if os.path.isfile(path):
-    	#if urlparse(cfg):
+    #if os.path.isfile(path):
+    if urlparse(cfg):
 	    #o=urlparse(cfg)
 	    #path=o.path
 	    #res=os.path.split(path)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -44,19 +44,19 @@ def main(cfg):
 	path=o.path
 	res=os.path.split(path)
 	cfg=res[1]'''
-    '''f = requests.get(cfg)
-    cfg=f.text'''
+    f = requests.get(cfg)
+    texts=f.text
 
     # Parse and read the config
-    if not os.path.isfile(cfg):
-            #if urlparse(cfg):
+    #if os.path.isfile(cfg):
+    if urlparse(cfg):
 	    #o=urlparse(cfg)
 	    #path=o.path
 	    #res=os.path.split(path)
 	    #cfg=res[1]
 	'''f = requests.get(cfg)
         cfg=f.text'''
-
+	cfg=texts
         with open(cfg, "r") as f:
             config = yaml.full_load(f)
         global kubeconfig_path, wait_duration

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -39,17 +39,18 @@ def main(cfg):
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
     
-    '''if urlparse(cfg):
+    path=cfg
+    if urlparse(cfg):
 	o=urlparse(cfg)
 	path=o.path
-	res=os.path.split(path)
+	'''res=os.path.split(path)
 	cfg=res[1]'''
     '''f = requests.get(cfg)
     texts=f.text'''
 
     # Parse and read the config
-    #if os.path.isfile(cfg):
-    if urlparse(cfg):
+    if os.path.isfile(path):
+    	#if urlparse(cfg):
 	    #o=urlparse(cfg)
 	    #path=o.path
 	    #res=os.path.split(path)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -38,7 +38,7 @@ def main(cfg):
     # Start kraken
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
-
+    print(cfg)
     #if urlparse(cfg):
 	#o=urlparse(cfg)
 	#path=o.path

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -25,6 +25,7 @@ import kraken.network_chaos.actions as network_chaos
 import server as server
 from urllib.parse import urlparse
 import requests
+import pdb
 #import webbrowser
 
 
@@ -326,5 +327,6 @@ if __name__ == "__main__":
 	'''f = requests.get(options.cfg)
     	texts=f.text
         main(texts)'''
+	pdb.set_trace()
 	print(options.cfg)
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -36,6 +36,7 @@ def publish_kraken_status(status):
 # Main function
 def main(cfg):
     # Start kraken
+    print(cfg)
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
     

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -37,13 +37,12 @@ def main(cfg):
     # Start kraken
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
-    new=2
-    webbrowser.open(url,new=new)
-    #if urlparse(cfg):
-	#o=urlparse(cfg)
-	#path=o.path
-	#res=os.path.split(path)
-	#cfg=res[1]
+
+    if urlparse(cfg):
+	o=urlparse(cfg)
+	path=o.path
+	res=os.path.split(path)
+	cfg=res[1]
 
     # Parse and read the config
     if os.path.isfile(cfg):

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -310,6 +310,7 @@ if __name__ == "__main__":
 	    path=o.path
 	    res=os.path.split(path)
 	    options.cfg=res[1]'''
+	print(options.cfg)
 	f = requests.get(options.cfg)
 	options.cfg=f.text
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -38,14 +38,19 @@ def main(cfg):
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
 
-    if urlparse(cfg):
-	o=urlparse(cfg)
-	path=o.path
-	res=os.path.split(path)
-	cfg=res[1]
+    #if urlparse(cfg):
+	#o=urlparse(cfg)
+	#path=o.path
+	#res=os.path.split(path)
+	#cfg=res[1]
 
     # Parse and read the config
     if os.path.isfile(cfg):
+	if urlparse(cfg):
+	    o=urlparse(cfg)
+	    path=o.path
+	    res=os.path.split(path)
+	    cfg=res[1]
         with open(cfg, "r") as f:
             config = yaml.full_load(f)
         global kubeconfig_path, wait_duration

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -39,19 +39,19 @@ def main(cfg):
     logging.info("Starting kraken")
 
     # Parse and read the config
-    flag=0
+    flag = 0
     if os.path.isfile(cfg):
-        flag=1
+        flag = 1
         with open(cfg, "r") as f:
             config = yaml.full_load(f)
    
     if urlparse(cfg):
-        flag=1
+        flag = 1
         f = requests.get(cfg)
-        texts=f.text
-        config=yaml.safe_load(texts)
+        texts = f.text
+        config = yaml.safe_load(texts)
 
-    if flag==1:
+    if flag == 1:
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
         kubeconfig_path = config["kraken"].get("kubeconfig_path", "")

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -47,9 +47,9 @@ def main(cfg):
             config = yaml.full_load(f)
    
     if urlparse(cfg):
-	    f = requests.get(cfg)
-    	texts=f.text
-	    config=yaml.safe_load(texts)
+        f = requests.get(cfg)
+        texts=f.text
+        config=yaml.safe_load(texts)
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
         kubeconfig_path = config["kraken"].get("kubeconfig_path", "")
@@ -301,6 +301,6 @@ if __name__ == "__main__":
         logging.error("Please check if you have passed the config")
         sys.exit(1)
     else:
-	#pdb.set_trace()
-	    print(options.cfg)
+       # pdb.set_trace()
+        print(options.cfg)
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -24,7 +24,7 @@ import kraken.pvc.pvc_scenario as pvc_scenario
 import kraken.network_chaos.actions as network_chaos
 import server as server
 from urllib.parse import urlparse
-import webbrowser
+#import webbrowser
 
 
 def publish_kraken_status(status):
@@ -46,11 +46,11 @@ def main(cfg):
 
     # Parse and read the config
     if os.path.isfile(cfg):
-	if urlparse(cfg):
-	    o=urlparse(cfg)
-	    path=o.path
-	    res=os.path.split(path)
-	    cfg=res[1]
+	#if urlparse(cfg):
+	    #o=urlparse(cfg)
+	    #path=o.path
+	    #res=os.path.split(path)
+	    #cfg=res[1]
         with open(cfg, "r") as f:
             config = yaml.full_load(f)
         global kubeconfig_path, wait_duration
@@ -304,4 +304,9 @@ if __name__ == "__main__":
         logging.error("Please check if you have passed the config")
         sys.exit(1)
     else:
+	if urlparse(options.cfg):
+	    o=urlparse(options.cfg)
+	    path=o.path
+	    res=os.path.split(path)
+	    options.cfg=res[1]
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -25,8 +25,6 @@ import kraken.network_chaos.actions as network_chaos
 import server as server
 from urllib.parse import urlparse
 import requests
-import pdb
-#import webbrowser
 
 
 def publish_kraken_status(status):
@@ -37,21 +35,23 @@ def publish_kraken_status(status):
 # Main function
 def main(cfg):
     # Start kraken
-    print(cfg)
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
 
     # Parse and read the config
+    flag=0
     if os.path.isfile(cfg):
-        logging.info("in os.path.isfile(cfg)")
+        flag=1
         with open(cfg, "r") as f:
             config = yaml.full_load(f)
    
     if urlparse(cfg):
-        logging.info("in urlparse(cfg)")
+        flag=1
         f = requests.get(cfg)
         texts=f.text
         config=yaml.safe_load(texts)
+
+    if flag==1:
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
         kubeconfig_path = config["kraken"].get("kubeconfig_path", "")
@@ -303,6 +303,4 @@ if __name__ == "__main__":
         logging.error("Please check if you have passed the config")
         sys.exit(1)
     else:
-        pdb.set_trace()
-        print(options.cfg)
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -36,7 +36,6 @@ def publish_kraken_status(status):
 # Main function
 def main(cfg):
     # Start kraken
-    print(cfg)
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
     
@@ -49,14 +48,14 @@ def main(cfg):
     cfg=f.text'''
 
     # Parse and read the config
-    #if os.path.isfile(cfg):
-    if urlparse(cfg):
+    if not os.path.isfile(cfg):
+            #if urlparse(cfg):
 	    #o=urlparse(cfg)
 	    #path=o.path
 	    #res=os.path.split(path)
 	    #cfg=res[1]
-	f = requests.get(cfg)
-        cfg=f.text
+	'''f = requests.get(cfg)
+        cfg=f.text'''
 
         with open(cfg, "r") as f:
             config = yaml.full_load(f)
@@ -316,4 +315,7 @@ if __name__ == "__main__":
 	    path=o.path
 	    res=os.path.split(path)
 	    options.cfg=res[1]'''
+	'''f = requests.get(options.cfg)
+    	texts=f.text
+        main(texts)'''
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -25,7 +25,7 @@ import kraken.network_chaos.actions as network_chaos
 import server as server
 from urllib.parse import urlparse
 import requests
-import pdb
+#import pdb
 #import webbrowser
 
 
@@ -40,33 +40,12 @@ def main(cfg):
     print(cfg)
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
-    
-    '''path=cfg
-    if urlparse(cfg):
-	o=urlparse(cfg)
-	path=o.path'''
-	'''res=os.path.split(path)
-	cfg=res[1]'''
-    '''f = requests.get(cfg)
-    texts=f.text'''
 
     # Parse and read the config
     #if os.path.isfile(path):
     if urlparse(cfg):
-	    #o=urlparse(cfg)
-	    #path=o.path
-	    #res=os.path.split(path)
-	    #cfg=res[1]
-	'''f = requests.get(cfg)
-        cfg=f.text'''
-	#cfg=texts
-        '''with open(cfg, "r") as f:
-            config = yaml.full_load(f)'''
 	f = requests.get(cfg)
     	texts=f.text
-	'''with open(texts,'r') as file:
-            config = yaml.full_load(file)'''
-       
 	config=yaml.safe_load(texts)
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
@@ -319,14 +298,6 @@ if __name__ == "__main__":
         logging.error("Please check if you have passed the config")
         sys.exit(1)
     else:
-	'''if urlparse(options.cfg):
-	    o=urlparse(options.cfg)
-	    path=o.path
-	    res=os.path.split(path)
-	    options.cfg=res[1]'''
-	'''f = requests.get(options.cfg)
-    	texts=f.text
-        main(texts)'''
-	pdb.set_trace()
+	#pdb.set_trace()
 	print(options.cfg)
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -36,6 +36,7 @@ def publish_kraken_status(status):
 # Main function
 def main(cfg):
     # Start kraken
+    print(cfg)
     print(pyfiglet.figlet_format("kraken"))
     logging.info("Starting kraken")
     
@@ -60,12 +61,12 @@ def main(cfg):
 	#cfg=texts
         '''with open(cfg, "r") as f:
             config = yaml.full_load(f)'''
-	    f = requests.get(cfg)
+	f = requests.get(cfg)
     	texts=f.text
 	'''with open(texts,'r') as file:
             config = yaml.full_load(file)'''
        
-	    config=yaml.safe_load(texts)
+	config=yaml.safe_load(texts)
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
         kubeconfig_path = config["kraken"].get("kubeconfig_path", "")
@@ -325,4 +326,5 @@ if __name__ == "__main__":
 	'''f = requests.get(options.cfg)
     	texts=f.text
         main(texts)'''
+	print(options.cfg)
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -24,6 +24,7 @@ import kraken.pvc.pvc_scenario as pvc_scenario
 import kraken.network_chaos.actions as network_chaos
 import server as server
 from urllib.parse import urlparse
+import requests
 #import webbrowser
 
 
@@ -304,9 +305,11 @@ if __name__ == "__main__":
         logging.error("Please check if you have passed the config")
         sys.exit(1)
     else:
-	if urlparse(options.cfg):
+	'''if urlparse(options.cfg):
 	    o=urlparse(options.cfg)
 	    path=o.path
 	    res=os.path.split(path)
-	    options.cfg=res[1]
+	    options.cfg=res[1]'''
+	f = requests.get(options.cfg)
+	options.cfg=f.text
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -44,8 +44,8 @@ def main(cfg):
 	path=o.path
 	res=os.path.split(path)
 	cfg=res[1]'''
-    f = requests.get(cfg)
-    texts=f.text
+    '''f = requests.get(cfg)
+    texts=f.text'''
 
     # Parse and read the config
     #if os.path.isfile(cfg):
@@ -56,9 +56,11 @@ def main(cfg):
 	    #cfg=res[1]
 	'''f = requests.get(cfg)
         cfg=f.text'''
-	    cfg=texts
-        with open(cfg, "r") as f:
-            config = yaml.full_load(f)
+	#cfg=texts
+        '''with open(cfg, "r") as f:
+            config = yaml.full_load(f)'''
+	f = requests.get(cfg)
+    	config=f.text
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
         kubeconfig_path = config["kraken"].get("kubeconfig_path", "")

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -56,7 +56,7 @@ def main(cfg):
 	    #cfg=res[1]
 	'''f = requests.get(cfg)
         cfg=f.text'''
-	cfg=texts
+	    cfg=texts
         with open(cfg, "r") as f:
             config = yaml.full_load(f)
         global kubeconfig_path, wait_duration

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -62,7 +62,10 @@ def main(cfg):
             config = yaml.full_load(f)'''
 	f = requests.get(cfg)
     	texts=f.text
-	config=yaml.safe_load(texts)
+	with open(texts,'r') as file:
+            config = yaml.full_load(file)
+
+	#config=yaml.safe_load(texts)
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
         kubeconfig_path = config["kraken"].get("kubeconfig_path", "")

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -43,10 +43,12 @@ def main(cfg):
 
     # Parse and read the config
     if os.path.isfile(cfg):
+        logging.info("in os.path.isfile(cfg)")
         with open(cfg, "r") as f:
             config = yaml.full_load(f)
    
     if urlparse(cfg):
+        logging.info("in urlparse(cfg)")
         f = requests.get(cfg)
         texts=f.text
         config=yaml.safe_load(texts)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -25,7 +25,7 @@ import kraken.network_chaos.actions as network_chaos
 import server as server
 from urllib.parse import urlparse
 import requests
-#import pdb
+import pdb
 #import webbrowser
 
 
@@ -303,6 +303,6 @@ if __name__ == "__main__":
         logging.error("Please check if you have passed the config")
         sys.exit(1)
     else:
-       # pdb.set_trace()
+        pdb.set_trace()
         print(options.cfg)
         main(options.cfg)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -60,12 +60,12 @@ def main(cfg):
 	#cfg=texts
         '''with open(cfg, "r") as f:
             config = yaml.full_load(f)'''
-	f = requests.get(cfg)
+	    f = requests.get(cfg)
     	texts=f.text
 	'''with open(texts,'r') as file:
             config = yaml.full_load(file)'''
        
-	config=yaml.safe_load(texts)
+	    config=yaml.safe_load(texts)
         global kubeconfig_path, wait_duration
         distribution = config["kraken"].get("distribution", "openshift")
         kubeconfig_path = config["kraken"].get("kubeconfig_path", "")


### PR DESCRIPTION
The earlier implementation reads the scenarios to run using file paths, having a way to define scenarios over http will make it more easy for users to run their test configurations.
So here in this, I have worked to write the configurations in such a way that earlier it didn't ran on http server. Now, with current implementation, scenarios can be defined on the file system as well as directly over http.