### PR TITLE
Update Litmus version in config_performance.yaml

### DIFF
--- a/config/config_performance.yaml
+++ b/config/config_performance.yaml
@@ -5,7 +5,7 @@ kraken:
     port: 8081
     publish_kraken_status: True                            # Can be accessed at http://0.0.0.0:8081
     signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
-    litmus_version: v1.10.0                                # Litmus version to install
+    litmus_version: v1.13.6                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   pod_scenarios:                                 # List of chaos pod scenarios to load


### PR DESCRIPTION
### Description
Update Litmus version to match `config.yaml`

### Fixes
v1.10 uses a different case for `Experimentstatus` than v1.13 and thus will always fail.
