### PR TITLE
Set itsdangerous package to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ python-ipmi
 podman-compose
 docker-compose
 jinja2>=3.0.1
+itsdangerous==2.0.1


### PR DESCRIPTION
### Description
Since import of JSON is deprecated from itsdangerous version 2.1.0 [1], this patch fixes the version to 2.0.1.
By fixing to version, we can avoid the below import error.
Error "from itsdangerous import json as _json ImportError: cannot import name 'json' from 'itsdangerous'"

[1] https://itsdangerous.palletsprojects.com/en/2.1.x/changes/#version-2-1-0