### PR TITLE
set jinja2 to 3.0.3 and werkzeug to 2.03

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,8 @@ openshift-client
 python-ipmi
 podman-compose
 docker-compose
-jinja2>=3.0.1
+jinja2==3.0.3
 itsdangerous==2.0.1
+werkzeug==2.0.3
 aliyun-python-sdk-core-v3
 aliyun-python-sdk-ecs


### PR DESCRIPTION
### Description
Since jinja2 3.1.0, escape need to be imported from MarkupSafe, which conflicts with flask1.x.x, so pining jinja2 to 3.0.3 to work with flask 1.x.x and latest version of werkzeug deprecates BaseResponse hence pining to 2.0.3.
